### PR TITLE
feat(plugins): add malware triage rule sets and threat-intel lists

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -118,6 +118,44 @@ plugins:
     size: "50KB"
     tags: [recon, patterns, gf]
 
+  # ── YARA Rules ───────────────────────────────────────────────
+  capa-rules:
+    repo: https://github.com/mandiant/capa-rules
+    type: yara-rules
+    description: "Mandiant capa capability rules for PE/ELF/.NET"
+    size: "8MB"
+    tags: [malware, capa, capabilities, mandiant]
+
+  signature-base:
+    repo: https://github.com/Neo23x0/signature-base
+    type: yara-rules
+    description: "Florian Roth's YARA rules — APT, webshells, hack tools, maldocs"
+    size: "40MB"
+    tags: [malware, apt, webshells, hacktools, neo23x0]
+
+  yara-rules-community:
+    repo: https://github.com/YARA-Rules/rules
+    type: yara-rules
+    description: "Community-maintained YARA rules across malware families"
+    size: "20MB"
+    tags: [malware, yara, community]
+
+  # ── Sigma Rules ──────────────────────────────────────────────
+  sigma:
+    repo: https://github.com/SigmaHQ/sigma
+    type: sigma
+    description: "SigmaHQ detection rules for logs and EDR"
+    size: "30MB"
+    tags: [detection, siem, edr, sigma]
+
+  # ── Threat Intel ─────────────────────────────────────────────
+  misp-warninglists:
+    repo: https://github.com/MISP/misp-warninglists
+    type: threat-intel
+    description: "MISP warning lists for false-positive reduction on IOCs"
+    size: "60MB"
+    tags: [misp, ioc, warninglists, threat-intel]
+
   # ── Shell Themes ─────────────────────────────────────────────
   powerlevel10k:
     repo: https://github.com/romkatv/powerlevel10k


### PR DESCRIPTION
## What

Adds five rule-set / threat-intel plugin entries used by the new CyberSandbox malware triage tool bundle, plus two new plugin types to the registry schema.

### New plugins

| Name | Type | Upstream | Size |
| --- | --- | --- | --- |
| `capa-rules` | yara-rules | mandiant/capa-rules | 8MB |
| `signature-base` | yara-rules | Neo23x0/signature-base | 40MB |
| `yara-rules-community` | yara-rules | YARA-Rules/rules | 20MB |
| `sigma` | sigma | SigmaHQ/sigma | 30MB |
| `misp-warninglists` | threat-intel | MISP/misp-warninglists | 60MB |

### New plugin types

- `yara-rules` — YARA detection rule collections
- `sigma` — Sigma detection rules (convert via sigma-cli to Splunk / Elastic / Sentinel)
- `threat-intel` — IOC / FP-reduction lists

## Why

Pairs with [ProwlrBot/CyberBox#19](https://github.com/ProwlrBot/CyberBox/pull/19), which ships the malware triage tool installer (`install-malware-tools.sh`) and a plugins showcase page that points operators at `csbx install <name>` for each of these rule sets.

## Convention compliance

- Alphabetical within each new `type` block
- All upstreams are OSS-compatible (GPL / MIT / CC-BY-SA / public domain)
- All upstreams are actively maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)